### PR TITLE
import com.mojolly.scalate.ScalatePlugin._ must be the 1st line in build.sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ libraryDependencies <+= sbtVersion(v => "com.mojolly.scalate" %% "xsbt-scalate-g
 Configure the plugin in `build.sbt`:
 
 ```scala
-import ScalatePlugin._
+import com.mojolly.scalate.ScalatePlugin._  // Must be the 1st line
 
 seq(scalateSettings:_*)
       


### PR DESCRIPTION
After reading the source code of xsbt-scalate-generate and doing some experiment, I managed to make it work with SBT 0.11.2.

This line must be the 1st line in build.sbt:
import com.mojolly.scalate.ScalatePlugin._
