### PR TITLE
Fixes a syntax error of the configuration example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ scalateTemplateConfig in Compile <<= (sourceDirectory in Compile){ base =>
       Some("mailTmpl")
     )
   )
-)
+}
 
 ```
 


### PR DESCRIPTION
I found the configuration example in `README.md` has a syntax error, so I have fixed it.

Thanks.
